### PR TITLE
codegen: Add strings for global variables.

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -261,7 +261,10 @@ codegen_generate_global_variable_for_primitive (struct node* node)
         /* Handle the value.  */
         if (node->var.val->type == NODE_TYPE_STRING)
         {
-            #warning "Dont forget to handle the string value."
+            const char* label = codegen_register_string (node->var.val->sval);
+            asm_push ("%s: %s %s", node->var.name, \
+                      asm_keyword_for_size (variable_size (node), tmp_buf), \
+                      label);
         }
         else
         {

--- a/test.c
+++ b/test.c
@@ -1,1 +1,1 @@
-int a = 50;
+const char* hello = "hello";


### PR DESCRIPTION
When a string is assigned to a global variable,
it will be placed in the ".data" section of the
assembly file.

    # C
    const char* hello = "hello";

    # Assembly
    section .data
    hello: db str_1